### PR TITLE
Allow using custom linker scripts

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -49,9 +49,9 @@ env.Append(
     ],
 
     LINKFLAGS=[
-        "-T", join(
+        "-T", env.BoardConfig().get("build.ldscript", join(
             platform.get_package_dir("framework-arduinoxmc"),
-            "variants", env.BoardConfig().get("build.mcu"), "linker_script.ld"
+            "variants", env.BoardConfig().get("build.mcu"), "linker_script.ld")
         )
     ],
 


### PR DESCRIPTION
This will allow users to specify any linker script from `platformio.ini` file using the following syntax:

```ini
[env:xmc1100_boot_kit]
platform = infineonxmc
board = xmc1100_boot_kit
framework = arduino

board_build.ldscript = custom_ldscript.ld
```
This is a more correct way of specifying it in comparison with using the `-Wl,-T` flag.