### PR TITLE
Fix device type in reset command description

### DIFF
--- a/misc/svd/XMC4800.svd
+++ b/misc/svd/XMC4800.svd
@@ -44819,7 +44819,7 @@
 					<fields>
 						<field>
 							<name>RESET_CMD</name>
-							<description>Reset commands issued by XMC4700</description>
+							<description>Reset commands issued by XMC4800</description>
 							<lsb>0</lsb>
 							<msb>7</msb>
 							<access>read-only</access>


### PR DESCRIPTION
An assumed typo in the XMC4800 system view description file is now fixed.